### PR TITLE
chore: support multiple src files in makefile build

### DIFF
--- a/libs/hashes/deps.mk
+++ b/libs/hashes/deps.mk
@@ -1,1 +1,1 @@
-DEPS := primitive-types
+DEPS := utils primitive-types


### PR DESCRIPTION
**Description**
Refactors Makefile to support lib builds of multiple src files. This is achieved by compiling each `.c` file individually and then passing them all when building the `shared` lib.