### PR TITLE
ci: use clang-format v19

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # https://apt.llvm.org/
+      - name: Install clang-format v19
+        run: |
+          sudo apt remove -y clang clang-format
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 19
+          sudo apt install clang-format-19
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-19 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-19
       - uses: actions/checkout@v4
       - name: "Check format"
         run: make check_fmt


### PR DESCRIPTION
**Description**
Update ci to use clang-format v19. This change is necessary as there are differences between the diff output in v18 and v19.