### PR TITLE
refactor: biguint take out param in all operations

### DIFF
--- a/libs/digital-signature/src/rsa.c
+++ b/libs/digital-signature/src/rsa.c
@@ -35,8 +35,7 @@ void rsa_gen_key_pair(RSAKeyPair *key_pair) {
     biguint_random_prime(&q);
 
     BigUint n = biguint_new_heap(key_size_in_bytes);
-    biguint_cpy(&n, p);
-    biguint_mul(&n, q);
+    biguint_mul(p, q, &n);
 
     // Carmichael's totient (lambda) of n outputs the smallest integer m, such that for every integer coprime to n, it
     // holds that:
@@ -47,8 +46,8 @@ void rsa_gen_key_pair(RSAKeyPair *key_pair) {
     // https://en.wikipedia.org/wiki/Carmichael_function
     BigUint one = biguint_new_heap(key_size_in_bytes);
     biguint_one(&one);
-    biguint_sub(&p, one);
-    biguint_sub(&q, one);
+    biguint_sub(p, one, &p);
+    biguint_sub(q, one, &q);
 
     BigUint lambda_n = biguint_new_heap(key_size_in_bytes);
     biguint_lcm(p, q, &lambda_n);

--- a/libs/math/src/arithmetics.c
+++ b/libs/math/src/arithmetics.c
@@ -29,7 +29,7 @@ void biguint_lcm(BigUint a, BigUint b, BigUint *out) {
 
     BigUint gcd = biguint_new_heap(out->size);
     biguint_gcd(x, y, &gcd);
-    biguint_mul(&x, y);
+    biguint_mul(x, y, &x);
     biguint_div(x, gcd, out);
 
     biguint_free(&gcd, &x, &y);
@@ -40,8 +40,7 @@ void biguint_lcm(BigUint a, BigUint b, BigUint *out) {
 // https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm#Modular_integers
 int biguint_bezout_identity_mod_holds(BigUint a, BigUint t, BigUint m, BigUint gcd) {
     BigUint at = biguint_new_heap(a.size);
-    biguint_cpy(&at, a);
-    biguint_mul(&at, t);
+    biguint_mul(a, t, &at);
     biguint_mod(at, m, &at);
     if (biguint_cmp(at, gcd) != 0) {
         return 0;
@@ -78,22 +77,16 @@ void biguint_extended_euclidean_algorithm(BigUint a, BigUint b, ExtendedEuclidea
         biguint_div(rp, ri, &quot);
 
         // r = r_{i-1} - q_i * r_i
-        biguint_cpy(&qr, ri);
-        biguint_mul(&qr, quot);
-        biguint_cpy(&r, rp);
-        biguint_sub(&r, qr);
+        biguint_mul(ri, quot, &qr);
+        biguint_sub(rp, qr, &r);
 
         // s = s_{i-1} - q_i * s_i
-        biguint_cpy(&qs, si);
-        biguint_mul(&qs, quot);
-        biguint_cpy(&s, sp);
-        biguint_sub(&s, qs);
+        biguint_mul(si, quot, &qs);
+        biguint_sub(sp, qs, &s);
 
         // t = t_{i-1} - q_i * t_i
-        biguint_cpy(&qt, ti);
-        biguint_mul(&qt, quot);
-        biguint_cpy(&t, tp);
-        biguint_sub(&t, qt);
+        biguint_mul(ti, quot, &qt);
+        biguint_sub(tp, qt, &t);
 
         // update values for next iteration
         biguint_cpy(&rp, ri);
@@ -130,7 +123,7 @@ void biguint_inverse_mod(BigUint a, BigUint n, BigUint *out) {
         biguint_zero(out);
     } else {
         if (alg.sk_sign == -1) {
-            biguint_add(&alg.sk, n);
+            biguint_add(alg.sk, n, &alg.sk);
         }
         biguint_cpy(out, alg.sk);
     }

--- a/libs/math/src/primes.c
+++ b/libs/math/src/primes.c
@@ -60,14 +60,12 @@ int biguint_is_prime_solovay_strassen(BigUint p) {
     BigUint two = biguint_new_heap(p.size);
     biguint_from_u64(2, &two);
 
-    BigUint exponent = biguint_new_heap(p.size);
-    biguint_cpy(&exponent, p);
-    biguint_sub(&exponent, one);
-    biguint_div(exponent, two, &exponent);
-
     BigUint p_minus_one = biguint_new_heap(p.size);
     biguint_cpy(&p_minus_one, p);
-    biguint_sub(&p_minus_one, one);
+    biguint_sub(p, one, &p_minus_one);
+
+    BigUint exponent = biguint_new_heap(p.size);
+    biguint_div(p_minus_one, two, &exponent);
 
     BigUint a = biguint_new_heap(p.size);
     BigUint rem = biguint_new_heap(p.size);
@@ -87,7 +85,7 @@ int biguint_is_prime_solovay_strassen(BigUint p) {
         // since we check that gcd(a, p) == 1
         // j = {-1,1} so we don't have to check if it == 0
         int j = jacobi(a, p);
-        biguint_pow_mod(&a, exponent, p);
+        biguint_pow_mod(a, exponent, p, &a);
         biguint_mod(a, p, &rem);
 
         // (p - 1) mod p = -1 mod p
@@ -152,7 +150,6 @@ int jacobi(BigUint a, BigUint n) {
 
     BigUint exponent = biguint_new_heap(a.size);
     BigUint exponent_two = biguint_new_heap(a.size);
-    BigUint exp_result = biguint_new_heap(a.size);
     BigUint next = biguint_new_heap(a.size);
 
     int result;
@@ -160,15 +157,15 @@ int jacobi(BigUint a, BigUint n) {
     if (biguint_is_even(a)) {
         biguint_cpy(&exponent, n);
         biguint_from_u64(2, &num);
-        biguint_pow(&exponent, num);
+        biguint_pow(exponent, num, &exponent);
         biguint_from_u64(1, &num);
-        biguint_sub(&exponent, num);
+        biguint_sub(exponent, num, &exponent);
         biguint_from_u64(8, &num);
-        biguint_div(exponent, num, &exp_result);
+        biguint_div(exponent, num, &exponent);
 
         // (-1)^n = { - 1 if n is even, - -1 if n is odd }
         int calc;
-        if (biguint_is_even(exp_result))
+        if (biguint_is_even(exponent))
             calc = 1;
         else
             calc = -1;
@@ -179,18 +176,18 @@ int jacobi(BigUint a, BigUint n) {
         result = calc * jacobi(next, n);
     } else {
         biguint_cpy(&exponent, a);
-        biguint_sub(&exponent, num);
+        biguint_sub(exponent, num, &exponent);
 
         biguint_cpy(&exponent_two, n);
-        biguint_sub(&exponent_two, num);
+        biguint_sub(exponent_two, num, &exponent_two);
 
-        biguint_mul(&exponent, exponent_two);
+        biguint_mul(exponent, exponent_two, &exponent);
         biguint_from_u64(4, &num);
-        biguint_div(exponent, num, &exp_result);
+        biguint_div(exponent, num, &exponent);
 
         // (-1)^n = { - 1 if n is even, - -1 if n is odd }
         int calc;
-        if (biguint_is_even(exp_result))
+        if (biguint_is_even(exponent))
             calc = 1;
         else
             calc = -1;
@@ -200,7 +197,7 @@ int jacobi(BigUint a, BigUint n) {
         result = calc * jacobi(next, a);
     }
 
-    biguint_free(&exponent, &exponent_two, &exp_result, &next, &num);
+    biguint_free(&exponent, &exponent_two, &next, &num);
 
     return result;
 }

--- a/libs/primitive-types/benchmarks/biguint.c
+++ b/libs/primitive-types/benchmarks/biguint.c
@@ -7,7 +7,7 @@ void benchmark_add() {
     BigUint b = biguint_new(16);
     biguint_random(&a);
     biguint_random(&b);
-    biguint_add(&a, b);
+    biguint_add(a, b, &a);
 }
 
 void benchmark_sub() {
@@ -15,7 +15,7 @@ void benchmark_sub() {
     BigUint b = biguint_new(16);
     biguint_random(&a);
     biguint_random(&b);
-    biguint_sub(&a, b);
+    biguint_sub(a, b, &a);
 }
 
 void benchmark_divmod() {
@@ -33,7 +33,7 @@ void benchmark_mul() {
     BigUint b = biguint_new(16);
     biguint_random(&a);
     biguint_random(&b);
-    biguint_mul(&a, b);
+    biguint_mul(a, b, &a);
 }
 
 void benchmark_pow() {
@@ -41,7 +41,7 @@ void benchmark_pow() {
     BigUint b = biguint_new(16);
     biguint_random(&a);
     biguint_random(&b);
-    biguint_pow(&a, b);
+    biguint_pow(a, b, &a);
 }
 
 void benchmark_pow_mod() {
@@ -51,7 +51,7 @@ void benchmark_pow_mod() {
     biguint_random(&a);
     biguint_random(&b);
     biguint_random(&m);
-    biguint_pow_mod(&a, b, m);
+    biguint_pow_mod(a, b, m, &a);
 }
 
 int main() {

--- a/libs/primitive-types/include/biguint.h
+++ b/libs/primitive-types/include/biguint.h
@@ -16,12 +16,12 @@ typedef struct {
  * @param SIZE The number of limbs (64-bit integers) for the `BigUint`.
  *
  * @note
- * You must call `biguint_free_limbs` to release the memory after use to avoid memory leaks.
+ * You must call `biguint_free` to release the memory after use to avoid memory leaks.
  *
  * @example
  * ```
  * BigUint num = biguint_new_heap(10);  // Allocate a BigUint with 10 limbs on the heap
- * biguint_free_limbs(&num);  // Don't forget to free the memory after use!
+ * biguint_free(&num);  // Don't forget to free the memory after use!
  * ```
  */
 #define biguint_new_heap(SIZE)                                                                                         \
@@ -275,365 +275,219 @@ int biguint_is_zero(BigUint a);
 int biguint_cmp(BigUint a, BigUint b);
 
 /**
- * Frees the memory allocated for the limbs of a BigUint that was allocated on the heap.
+ * Adds two BigUint values and stores the result in `out`.
  *
- * @param a Pointer to the BigUint whose limbs should be freed.
- *
- * @example
- * ```
- * BigUint num = biguint_new_heap(5);
- * biguint_free_limbs(&num);  // Free the memory after use
- * ```
- */
-void biguint_free_limbs(BigUint *a);
-
-/**
- * Adds two BigUint values and stores the result in the first operand.
- *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to add.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
- * biguint_add(&a, b);  // Add `b` to `a`
+ * BigUint result = biguint_new(1);
+ * biguint_add(a, b, &result);  // Compute `a + b` and store it in `result`
  * ```
  */
-void biguint_add(BigUint *a, BigUint b);
+void biguint_add(BigUint a, BigUint b, BigUint *out);
 
 /**
- * Subtracts the second BigUint from the first and stores the result in the first operand.
+ * Subtracts `b` from `a` and stores the result in `out`.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to subtract.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
- * biguint_sub(&a, b);  // Subtract `b` from `a`
+ * BigUint result = biguint_new(1);
+ * biguint_sub(a, b, &result);  // Compute `a - b` and store it in `result`
  * ```
  */
-void biguint_sub(BigUint *a, BigUint b);
+void biguint_sub(BigUint a, BigUint b, BigUint *out);
 
 /**
- * Multiplies two BigUint values and stores the result in the first operand.
+ * Multiplies two BigUint values and stores the result in `out`.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to multiply.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
- * biguint_mul(&a, b);  // Multiply `a` and `b`
+ * BigUint result = biguint_new(1);
+ * biguint_mul(a, b, &result);  // Compute `a * b` and store it in `result`
  * ```
  */
-void biguint_mul(BigUint *a, BigUint b);
+void biguint_mul(BigUint a, BigUint b, BigUint *out);
 
 /**
  * Checks for overflow when adding two BigUint values.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to add.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result (optional).
  * @return 1 if overflow occurs, 0 otherwise.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
- * int overflow = biguint_overflow_add(&a, b);  // Check if adding `a` and `b` overflows
+ * BigUint result = biguint_new(1);
+ * int overflow = biguint_overflow_add(a, b, &result);  // Check if `a + b` overflows
  * ```
  */
-int biguint_overflow_add(BigUint *a, BigUint b);
+int biguint_overflow_add(BigUint a, BigUint b, BigUint *out);
 
 /**
- * Computes the addition of a + b (mod m).
+ * Computes `(a + b) mod m` and stores the result in `out`.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to add.
- * @param m The third BigUint defining the modulus.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param m The modulus.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
  * BigUint m = biguint_new(1);
- * biguint_add_mod(&a, b, m);
+ * BigUint result = biguint_new(1);
+ * biguint_add_mod(a, b, m, &result);  // Compute `(a + b) % m` and store in `result`
  * ```
  */
-void biguint_add_mod(BigUint *a, BigUint b, BigUint m);
+void biguint_add_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
 
 /**
- * Checks for overflow when subtracting two BigUint values.
+ * Computes `(a - b) mod m` and stores the result in `out`.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to subtract.
- * @return 1 if overflow occurs, 0 otherwise.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * int overflow = biguint_overflow_sub(&a, b);  // Check if subtracting `b` from `a` overflows
- * ```
- */
-int biguint_overflow_sub(BigUint *a, BigUint b);
-
-/**
- * Computes the substraction of a - b (mod m).
- *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to substract.
- * @param m The third BigUint defining the modulus.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param m The modulus.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
  * BigUint m = biguint_new(1);
- * biguint_sub_mod(&a, b, m);
+ * BigUint result = biguint_new(1);
+ * biguint_sub_mod(a, b, m, &result);  // Compute `(a - b) % m` and store in `result`
  * ```
  */
-void biguint_sub_mod(BigUint *a, BigUint b, BigUint m);
+void biguint_sub_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
 
 /**
- * Checks for overflow when multiplying two BigUint values.
+ * Computes `(a * b) mod m` and stores the result in `out`.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to multiply.
- * @return 1 if overflow occurs, 0 otherwise.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * int overflow = biguint_overflow_mul(&a, b);  // Check if multiplying `a` and `b` overflows
- * ```
- */
-int biguint_overflow_mul(BigUint *a, BigUint b);
-
-/**
- * Computes the multiplication of a * b (mod m).
- *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to multiply.
- * @param m The third BigUint defining the modulus.
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param m The modulus.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint a = biguint_new(1);
  * BigUint b = biguint_new(1);
  * BigUint m = biguint_new(1);
- * biguint_mul_mod(&a, b, m);
+ * BigUint result = biguint_new(1);
+ * biguint_mul_mod(a, b, m, &result);  // Compute `(a * b) % m` and store in `result`
  * ```
  */
-void biguint_mul_mod(BigUint *a, BigUint b, BigUint m);
+void biguint_mul_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
 
 /**
- * Computes the power of a BigUint to an exponent and checks for overflow.
+ * Computes `a^exponent` and stores the result in `out`.
  *
- * @param a Pointer to the base (BigUint).
- * @param exponent The exponent (BigUint).
- * @return Returns 1 if the operation overflows, 0 otherwise.
- *
- * @example
- * ```
- * BigUint base = biguint_new(2);
- * BigUint exponent = biguint_new(1000);
- * int has_overflowed = biguint_overflow_pow(&base, exponent);
- * ```
- */
-int biguint_overflow_pow(BigUint *a, BigUint exponent);
-
-/**
- * Computes the power of a BigUint raised to an exponent.
- *
- * @param a Pointer to the base (BigUint). The result is stored in this variable.
- * @param exponent The exponent (BigUint).
+ * @param a The base BigUint.
+ * @param exponent The exponent BigUint.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint base = biguint_new(2);
  * BigUint exponent = biguint_new(10);
- * biguint_pow(&base, exponent);  // `base` is now 1024
+ * BigUint result = biguint_new(1);
+ * biguint_pow(base, exponent, &result);  // Compute `2^10` and store in `result`
  * ```
  */
-void biguint_pow(BigUint *a, BigUint exponent);
+void biguint_pow(BigUint a, BigUint exponent, BigUint *out);
 
 /**
- * Computes the power of a BigUint keeping the result in bounds over a mod m
+ * Computes `(a^exponent) mod m` and stores the result in `out`.
  *
- * @param a Pointer to the base (BigUint). The result is stored in this variable.
- * @param m The modulus (BigUint). The result is computed modulo this value.
- * @param exponent The exponent (BigUint). The base `a` is raised to this power.
+ * @param a The base BigUint.
+ * @param exponent The exponent BigUint.
+ * @param m The modulus.
+ * @param out Pointer to store the result.
  *
  * @example
  * ```
  * BigUint base = biguint_new(2);
+ * BigUint exponent = biguint_new(10);
  * BigUint modulus = biguint_new(1000);
- * BigUint exponent = biguint_new(10);
- * biguint_pow_mod(&base, modulus, exponent);  // `base` is now (2^10) % 1000 = 24
+ * BigUint result = biguint_new(1);
+ * biguint_pow_mod(base, exponent, modulus, &result);  // Compute `(2^10) % 1000`
  * ```
  */
-void biguint_pow_mod(BigUint *a, BigUint exponent, BigUint m);
+void biguint_pow_mod(BigUint a, BigUint exponent, BigUint m, BigUint *out);
 
 /**
- * Divides one BigUint by another, storing the quotient and remainder.
+ * Computes bitwise AND between `a` and `b` and stores the result in `out`.
  *
- * @param a The dividend (BigUint).
- * @param b The divisor (BigUint).
- * @param quot Pointer to store the quotient.
- * @param rem Pointer to store the remainder.
- *
- * @example
- * ```
- * BigUint a = biguint_new(2);
- * BigUint b = biguint_new(2);
- * BigUint quot, rem;
- * biguint_divmod(a, b, &quot, &rem);  // Divide `a` by `b` and store the quotient and remainder
- * ```
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
  */
-void biguint_divmod(BigUint a, BigUint b, BigUint *quot, BigUint *rem);
+void biguint_bitand(BigUint a, BigUint b, BigUint *out);
 
 /**
- * Computes the quotient of one BigUint divided by another.
+ * Computes bitwise OR between `a` and `b` and stores the result in `out`.
  *
- * @param a The dividend (BigUint).
- * @param b The divisor (BigUint).
- * @param out Pointer to store the quotient.
- *
- * @example
- * ```
- * BigUint a = biguint_new(10);
- * BigUint b = biguint_new(2);
- * BigUint quot;
- * biguint_div(a, b, &quot);  // Quotient `quot` will be 5
- * ```
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
  */
-void biguint_div(BigUint a, BigUint b, BigUint *out);
+void biguint_bitor(BigUint a, BigUint b, BigUint *out);
 
 /**
- * Computes the remainder of one BigUint divided by another.
+ * Computes bitwise XOR between `a` and `b` and stores the result in `out`.
  *
- * @param a The dividend (BigUint).
- * @param b The divisor (BigUint).
- * @param out Pointer to store the remainder.
- *
- * @example
- * ```
- * BigUint a = biguint_new(10);
- * BigUint b = biguint_new(3);
- * BigUint rem;
- * biguint_mod(a, b, &rem);  // Remainder `rem` will be 1
- * ```
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
  */
-void biguint_mod(BigUint a, BigUint b, BigUint *out);
+void biguint_bitxor(BigUint a, BigUint b, BigUint *out);
 
 /**
- * Checks if a BigUint is even.
+ * Computes bitwise NOT of `a` and stores the result in `out`.
  *
- * @param a The BigUint to check.
- * @return Returns 1 if `a` is even, 0 otherwise.
- *
- * @example
- * ```
- * BigUint num = biguint_new(10);
- * if (biguint_is_even(num)) {
- *     printf("The number is even.\n");
- * } else {
- *     printf("The number is odd.\n");
- * }
- * ```
+ * @param a The BigUint operand.
+ * @param out Pointer to store the result.
  */
-int biguint_is_even(BigUint a);
+void biguint_bitnot(BigUint a, BigUint *out);
 
 /**
- * Performs a bitwise AND between two BigUint values.
+ * Performs a right shift on `a` and stores the result in `out`.
  *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to perform AND with.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * biguint_bitand(&a, b);  // Perform bitwise AND between `a` and `b`
- * ```
- */
-void biguint_bitand(BigUint *a, BigUint b);
-
-/**
- * Performs a bitwise OR between two BigUint values.
- *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to perform OR with.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * biguint_bitor(&a, b);  // Perform bitwise OR between `a` and `b`
- * ```
- */
-void biguint_bitor(BigUint *a, BigUint b);
-
-/**
- * Performs a bitwise XOR between two BigUint values.
- *
- * @param a Pointer to the first BigUint (result stored here).
- * @param b The second BigUint to perform XOR with.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * biguint_bitxor(&a, b);  // Perform bitwise XOR between `a` and `b`
- * ```
- */
-void biguint_bitxor(BigUint *a, BigUint b);
-
-/**
- * Performs a bitwise NOT on a BigUint value.
- *
- * @param a Pointer to the BigUint to perform NOT on.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * biguint_bitnot(&a);  // Perform bitwise NOT on `a`
- * ```
- */
-void biguint_bitnot(BigUint *a);
-
-/**
- * Performs a right shift (logical shift) on a BigUint value.
- *
- * @param a Pointer to the BigUint to shift.
+ * @param a The BigUint operand.
  * @param shift The number of positions to shift.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * biguint_shr(&a, 2);  // Perform a logical right shift by 2 positions
- * ```
+ * @param out Pointer to store the result.
  */
-void biguint_shr(BigUint *a, int shift);
+void biguint_shr(BigUint a, int shift, BigUint *out);
 
 /**
- * Performs a left shift on a BigUint value.
+ * Performs a left shift on `a` and stores the result in `out`.
  *
- * @param b Pointer to the BigUint to shift.
+ * @param a The BigUint operand.
  * @param shift The number of positions to shift.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * biguint_shl(&a, 2);  // Perform a left shift by 2 positions
- * ```
+ * @param out Pointer to store the result.
  */
-void biguint_shl(BigUint *b, int shift);
+void biguint_shl(BigUint a, int shift, BigUint *out);
 
 /**
  * Debugging: Prints a raw representation of a BigUint value (binary).

--- a/libs/primitive-types/include/biguint.h
+++ b/libs/primitive-types/include/biguint.h
@@ -44,6 +44,8 @@ typedef struct {
     for (size_t i = 0; i < sizeof(ANONYMOUS_VARIABLE(args)) / sizeof(ANONYMOUS_VARIABLE(args)[0]); i++)                \
         biguint_free_limbs(ANONYMOUS_VARIABLE(args)[i]);
 
+void biguint_free_limbs(BigUint *a);
+
 /**
  * Creates a `BigUint` on the stack with a specified number of limbs, all initialized to 0.
  *
@@ -399,6 +401,76 @@ void biguint_sub_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
  * ```
  */
 void biguint_mul_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
+
+/**
+ * Divides one BigUint by another, storing the quotient and remainder.
+ *
+ * @param a The dividend (BigUint).
+ * @param b The divisor (BigUint).
+ * @param quot Pointer to store the quotient.
+ * @param rem Pointer to store the remainder.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(2);
+ * BigUint b = biguint_new(2);
+ * BigUint quot, rem;
+ * biguint_divmod(a, b, &quot, &rem);  // Divide `a` by `b` and store the quotient and remainder
+ * ```
+ */
+void biguint_divmod(BigUint a, BigUint b, BigUint *quot, BigUint *rem);
+
+/**
+ * Computes the quotient of one BigUint divided by another.
+ *
+ * @param a The dividend (BigUint).
+ * @param b The divisor (BigUint).
+ * @param out Pointer to store the quotient.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(10);
+ * BigUint b = biguint_new(2);
+ * BigUint quot;
+ * biguint_div(a, b, &quot);  // Quotient `quot` will be 5
+ * ```
+ */
+void biguint_div(BigUint a, BigUint b, BigUint *out);
+
+/**
+ * Computes the remainder of one BigUint divided by another.
+ *
+ * @param a The dividend (BigUint).
+ * @param b The divisor (BigUint).
+ * @param out Pointer to store the remainder.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(10);
+ * BigUint b = biguint_new(3);
+ * BigUint rem;
+ * biguint_mod(a, b, &rem);  // Remainder `rem` will be 1
+ * ```
+ */
+void biguint_mod(BigUint a, BigUint b, BigUint *out);
+
+/**
+ * Checks if a BigUint is even.
+ *
+ * @param a The BigUint to check.
+ * @return Returns 1 if `a` is even, 0 otherwise.
+ *
+ * @example
+ * ```
+ * BigUint num = biguint_new(10);
+ * if (biguint_is_even(num)) {
+ *     printf("The number is even.\n");
+ * } else {
+ *     printf("The number is odd.\n");
+ * }
+ * ```
+ */
+int biguint_is_even(BigUint a);
 
 /**
  * Computes `a^exponent` and stores the result in `out`.

--- a/libs/primitive-types/include/biguint.h
+++ b/libs/primitive-types/include/biguint.h
@@ -277,57 +277,6 @@ int biguint_is_zero(BigUint a);
 int biguint_cmp(BigUint a, BigUint b);
 
 /**
- * Adds two BigUint values and stores the result in `out`.
- *
- * @param a The first BigUint operand.
- * @param b The second BigUint operand.
- * @param out Pointer to store the result.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * BigUint result = biguint_new(1);
- * biguint_add(a, b, &result);  // Compute `a + b` and store it in `result`
- * ```
- */
-void biguint_add(BigUint a, BigUint b, BigUint *out);
-
-/**
- * Subtracts `b` from `a` and stores the result in `out`.
- *
- * @param a The first BigUint operand.
- * @param b The second BigUint operand.
- * @param out Pointer to store the result.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * BigUint result = biguint_new(1);
- * biguint_sub(a, b, &result);  // Compute `a - b` and store it in `result`
- * ```
- */
-void biguint_sub(BigUint a, BigUint b, BigUint *out);
-
-/**
- * Multiplies two BigUint values and stores the result in `out`.
- *
- * @param a The first BigUint operand.
- * @param b The second BigUint operand.
- * @param out Pointer to store the result.
- *
- * @example
- * ```
- * BigUint a = biguint_new(1);
- * BigUint b = biguint_new(1);
- * BigUint result = biguint_new(1);
- * biguint_mul(a, b, &result);  // Compute `a * b` and store it in `result`
- * ```
- */
-void biguint_mul(BigUint a, BigUint b, BigUint *out);
-
-/**
  * Checks for overflow when adding two BigUint values.
  *
  * @param a The first BigUint operand.
@@ -344,6 +293,23 @@ void biguint_mul(BigUint a, BigUint b, BigUint *out);
  * ```
  */
 int biguint_overflow_add(BigUint a, BigUint b, BigUint *out);
+
+/**
+ * Adds two BigUint values and stores the result in `out`.
+ *
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(1);
+ * BigUint b = biguint_new(1);
+ * BigUint result = biguint_new(1);
+ * biguint_add(a, b, &result);  // Compute `a + b` and store it in `result`
+ * ```
+ */
+void biguint_add(BigUint a, BigUint b, BigUint *out);
 
 /**
  * Computes `(a + b) mod m` and stores the result in `out`.
@@ -365,6 +331,41 @@ int biguint_overflow_add(BigUint a, BigUint b, BigUint *out);
 void biguint_add_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
 
 /**
+ * Checks for overflow when adding two BigUint values.
+ *
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result (optional).
+ * @return 1 if overflow occurs, 0 otherwise.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(1);
+ * BigUint b = biguint_new(1);
+ * BigUint result = biguint_new(1);
+ * int overflow = biguint_overflow_sub(a, b, &result);  // Check if `a - b` overflows
+ * ```
+ */
+int biguint_overflow_sub(BigUint a, BigUint b, BigUint *out);
+
+/**
+ * Subtracts `b` from `a` and stores the result in `out`.
+ *
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(1);
+ * BigUint b = biguint_new(1);
+ * BigUint result = biguint_new(1);
+ * biguint_sub(a, b, &result);  // Compute `a - b` and store it in `result`
+ * ```
+ */
+void biguint_sub(BigUint a, BigUint b, BigUint *out);
+
+/**
  * Computes `(a - b) mod m` and stores the result in `out`.
  *
  * @param a The first BigUint operand.
@@ -382,6 +383,41 @@ void biguint_add_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
  * ```
  */
 void biguint_sub_mod(BigUint a, BigUint b, BigUint m, BigUint *out);
+
+/**
+ * Multiplies two BigUint values and stores the result in `out`.
+ *
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
+ * @return 1 if overflow occurs, 0 otherwise.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(1);
+ * BigUint b = biguint_new(1);
+ * BigUint result = biguint_new(1);
+ * int overflow = biguint_overflow_mul(a, b, &result); // Check if `a * b` overflows
+ * ```
+ */
+int biguint_overflow_mul(BigUint a, BigUint b, BigUint *out);
+
+/**
+ * Multiplies two BigUint values and stores the result in `out`.
+ *
+ * @param a The first BigUint operand.
+ * @param b The second BigUint operand.
+ * @param out Pointer to store the result.
+ *
+ * @example
+ * ```
+ * BigUint a = biguint_new(1);
+ * BigUint b = biguint_new(1);
+ * BigUint result = biguint_new(1);
+ * biguint_mul(a, b, &result);  // Compute `a * b` and store it in `result`
+ * ```
+ */
+void biguint_mul(BigUint a, BigUint b, BigUint *out);
 
 /**
  * Computes `(a * b) mod m` and stores the result in `out`.
@@ -471,6 +507,24 @@ void biguint_mod(BigUint a, BigUint b, BigUint *out);
  * ```
  */
 int biguint_is_even(BigUint a);
+
+/**
+ * Computes `a^exponent` and stores the result in `out` and checks for overflow.
+ *
+ * @param a The base BigUint.
+ * @param exponent The exponent BigUint.
+ * @param out Pointer to store the result.
+ * @return Returns 1 if the operation overflows, 0 otherwise.
+ *
+ * @example
+ * ```
+ * BigUint base = biguint_new(2);
+ * BigUint exponent = biguint_new(10);
+ * BigUint result = biguint_new(1);
+ * int biguint_overflow_pow(base, exponent, &result);  // Check if `a ^ exponent` overflows
+ * ```
+ */
+int biguint_overflow_pow(BigUint a, BigUint exponent, BigUint *out);
 
 /**
  * Computes `a^exponent` and stores the result in `out`.

--- a/libs/primitive-types/include/uint.h
+++ b/libs/primitive-types/include/uint.h
@@ -123,8 +123,8 @@
  */
 #define DEFINE_UINT_OVERFLOW_ADD(NAME, WORDS)                                                                          \
     NAME##_overflow_op NAME##_overflow_add(NAME a, NAME b) {                                                           \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        int overflow = biguint_overflow_add(&result, uint_to_biguint(b));                                              \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        int overflow = biguint_overflow_add(uint_to_biguint(a), uint_to_biguint(b), &result);                          \
         return (NAME##_overflow_op){.res = NAME##_from_biguint(result), .overflow = overflow};                         \
     }
 
@@ -135,8 +135,8 @@
  */
 #define DEFINE_UINT_ADD_MOD(NAME, WORDS)                                                                               \
     NAME NAME##_add_mod(NAME a, NAME b, NAME m) {                                                                      \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_add_mod(&result, uint_to_biguint(b), uint_to_biguint(m));                                              \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_add_mod(uint_to_biguint(a), uint_to_biguint(b), uint_to_biguint(m), &result);                          \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -147,8 +147,8 @@
  */                                                                                                                    \
 #define DEFINE_UINT_OVERFLOW_SUB(NAME, WORDS)                                                                          \
     NAME##_overflow_op NAME##_overflow_sub(NAME a, NAME b) {                                                           \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        int overflow = biguint_overflow_sub(&result, uint_to_biguint(b));                                              \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        int overflow = biguint_overflow_sub(uint_to_biguint(a), uint_to_biguint(b), &result);                          \
         return (NAME##_overflow_op){.res = NAME##_from_biguint(result), .overflow = overflow};                         \
     }
 
@@ -159,8 +159,8 @@
  */
 #define DEFINE_UINT_SUB_MOD(NAME, WORDS)                                                                               \
     NAME NAME##_sub_mod(NAME a, NAME b, NAME m) {                                                                      \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_sub_mod(&result, uint_to_biguint(b), uint_to_biguint(m));                                              \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_sub_mod(uint_to_biguint(a), uint_to_biguint(b), uint_to_biguint(m), &result);                          \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -171,8 +171,8 @@
  */
 #define DEFINE_UINT_BITAND(NAME, WORDS)                                                                                \
     NAME NAME##_bitand(NAME a, NAME b) {                                                                               \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_bitand(&result, uint_to_biguint(b));                                                                   \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_bitand(uint_to_biguint(a), uint_to_biguint(b), &result);                                               \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -183,8 +183,8 @@
  */
 #define DEFINE_UINT_BITOR(NAME, WORDS)                                                                                 \
     NAME NAME##_bitor(NAME a, NAME b) {                                                                                \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_bitor(&result, uint_to_biguint(b));                                                                    \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_bitor(uint_to_biguint(a), uint_to_biguint(b), &result);                                                \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -195,8 +195,8 @@
  */                                                                                                                    \
 #define DEFINE_UINT_BITXOR(NAME, WORDS)                                                                                \
     NAME NAME##_bitxor(NAME a, NAME b) {                                                                               \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_bitxor(&result, uint_to_biguint(b));                                                                   \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_bitxor(uint_to_biguint(a), uint_to_biguint(b), &result);                                               \
         return NAME##_from_biguint(result);                                                                            \
     }
 /**                                                                                                                    \
@@ -206,8 +206,8 @@
  */                                                                                                                    \
 #define DEFINE_UINT_BITNOT(NAME, WORDS)                                                                                \
     NAME NAME##_bitnot(NAME a) {                                                                                       \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_bitnot(&result);                                                                                       \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_bitnot(uint_to_biguint(a), &result);                                                                   \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -218,8 +218,8 @@
  */
 #define DEFINE_UINT_OVERFLOW_MUL(NAME, WORDS)                                                                          \
     NAME##_overflow_op NAME##_overflow_mul(NAME a, NAME b) {                                                           \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        int overflow = biguint_overflow_mul(&result, uint_to_biguint(b));                                              \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        int overflow = biguint_overflow_mul(uint_to_biguint(a), uint_to_biguint(b), &result);                          \
         return (NAME##_overflow_op){.res = NAME##_from_biguint(result), .overflow = overflow};                         \
     }
 
@@ -230,8 +230,8 @@
  */
 #define DEFINE_UINT_MUL_MOD(NAME, WORDS)                                                                               \
     NAME NAME##_mul_mod(NAME a, NAME b, NAME m) {                                                                      \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_mul_mod(&result, uint_to_biguint(b), uint_to_biguint(m));                                              \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_mul_mod(uint_to_biguint(a), uint_to_biguint(b), uint_to_biguint(m), &result);                          \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -242,8 +242,8 @@
  */
 #define DEFINE_UINT_OVERFLOW_POW(NAME, WORDS)                                                                          \
     NAME##_overflow_op NAME##_overflow_pow(NAME a, NAME exponent) {                                                    \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        int overflow = biguint_overflow_pow(&result, uint_to_biguint(exponent));                                       \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        int overflow = biguint_overflow_pow(uint_to_biguint(a), uint_to_biguint(exponent), &result);                   \
         return (NAME##_overflow_op){.res = NAME##_from_biguint(result), .overflow = overflow};                         \
     }
 
@@ -254,8 +254,8 @@
  */
 #define DEFINE_UINT_OVERFLOW_POW_MOD(NAME, WORDS)                                                                      \
     NAME NAME##_pow_mod(NAME a, NAME exponent, NAME m) {                                                               \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_pow_mod(&result, uint_to_biguint(exponent), uint_to_biguint(m));                                       \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_pow_mod(uint_to_biguint(a), uint_to_biguint(exponent), uint_to_biguint(m), &result);                   \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -274,8 +274,8 @@
  */
 #define DEFINE_UINT_SHL(NAME, WORDS)                                                                                   \
     NAME NAME##_shl(NAME a, int shift) {                                                                               \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_shl(&result, shift);                                                                                   \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_shl(uint_to_biguint(a), shift, &result);                                                               \
         return NAME##_from_biguint(result);                                                                            \
     }
 
@@ -286,8 +286,8 @@
  */
 #define DEFINE_UINT_SHR(NAME, WORDS)                                                                                   \
     NAME NAME##_shr(NAME a, int shift) {                                                                               \
-        BigUint result = uint_to_biguint(a);                                                                           \
-        biguint_shr(&result, shift);                                                                                   \
+        BigUint result = biguint_new(WORDS);                                                                           \
+        biguint_shr(uint_to_biguint(a), shift, &result);                                                               \
         return NAME##_from_biguint(result);                                                                            \
     }
 

--- a/libs/primitive-types/tests/biguint.c
+++ b/libs/primitive-types/tests/biguint.c
@@ -8,7 +8,7 @@ void test_biguint_overflow_add() {
     BigUint expected_result =
         biguint_new_with_limbs(4, {18446744073709551614ULL, 18446744073709551615ULL, 2199023255551ULL, 0});
 
-    int overflow = biguint_overflow_add(&first, second);
+    int overflow = biguint_overflow_add(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 0);
@@ -19,7 +19,7 @@ void test_biguint_overflow_add_with_overflow() {
     BigUint second = biguint_new_with_limbs(4, {UINT64_MAX, UINT64_MAX, UINT64_MAX, UINT64_MAX});
     BigUint expected_result = biguint_new_with_limbs(4, {UINT64_MAX - 1, UINT64_MAX, UINT64_MAX, UINT64_MAX});
 
-    int overflow = biguint_overflow_add(&first, second);
+    int overflow = biguint_overflow_add(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 1);
@@ -31,7 +31,7 @@ void test_biguint_add_mod() {
     BigUint mod = biguint_new_with_limbs(4, {UINT64_MAX, 0, 0, 0});
     BigUint expected_result = biguint_new_with_limbs(4, {UINT64_MAX - 1, 0, 0, 0});
 
-    biguint_add_mod(&first, second, mod);
+    biguint_add_mod(first, second, mod, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -42,7 +42,7 @@ void test_biguint_overflow_sub() {
     BigUint expected_result =
         biguint_new_with_limbs(4, {15526763422372331520ULL, 4427218577690292387ULL, 1088516511498ULL, 0});
 
-    int overflow = biguint_overflow_sub(&first, second);
+    int overflow = biguint_overflow_sub(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 0);
@@ -52,7 +52,7 @@ void test_biguint_overflow_sub_with_overflow() {
     BigUint first = biguint_new_with_limbs(4, {0, 0, 0, 0});
     BigUint second = biguint_new_with_limbs(4, {1, 1, 1, 1});
     BigUint expected_result = biguint_new_with_limbs(4, {UINT64_MAX, UINT64_MAX - 1, UINT64_MAX - 1, UINT64_MAX - 1});
-    int overflow = biguint_overflow_sub(&first, second);
+    int overflow = biguint_overflow_sub(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 1);
@@ -64,7 +64,7 @@ void test_biguint_sub_mod() {
     BigUint mod = biguint_new_with_limbs(4, {UINT64_MAX, UINT64_MAX, 0, 0});
     BigUint expected_result = biguint_new_with_limbs(4, {UINT64_MAX - 1, UINT64_MAX - 2, 0, 0});
 
-    biguint_sub_mod(&first, second, mod);
+    biguint_sub_mod(first, second, mod, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -73,7 +73,7 @@ void test_biguint_overflow_mul() {
     BigUint first = biguint_new_with_limbs(4, {18446744073709551615ULL, 0, 0, 0});
     BigUint second = biguint_new_with_limbs(4, {2919980651337220095ULL, 0, 0, 0});
     BigUint expected_result = biguint_new_with_limbs(4, {15526763422372331521ULL, 2919980651337220094ULL, 0, 0});
-    int overflow = biguint_overflow_mul(&first, second);
+    int overflow = biguint_overflow_mul(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 0);
@@ -84,7 +84,7 @@ void test_biguint_overflow_mul_with_overflow() {
     BigUint second = biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 0});
     BigUint expected_result = biguint_new_with_limbs(
         4, {15526763422372331521ULL, 4427218577690292387ULL, 17870282210899384074ULL, 14019525494141808257ULL});
-    int overflow = biguint_overflow_mul(&first, second);
+    int overflow = biguint_overflow_mul(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 1);
@@ -96,7 +96,7 @@ void test_biguint_mul_mod() {
     BigUint mod = biguint_new_with_limbs(4, {1, 0, 0, 0});
     BigUint expected_result = biguint_new_with_limbs(4, {0, 0, 0, 0});
 
-    biguint_mul_mod(&first, second, mod);
+    biguint_mul_mod(first, second, mod, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -105,7 +105,7 @@ void test_biguint_overflow_pow() {
     BigUint first = biguint_new_with_limbs(4, {18446744073709551615ULL, 0, 0, 0});
     BigUint second = biguint_new_with_limbs(4, {2, 0, 0, 0});
     BigUint expected_result = biguint_new_with_limbs(4, {1, 18446744073709551614ULL, 0, 0});
-    int overflow = biguint_overflow_pow(&first, second);
+    int overflow = biguint_overflow_pow(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 0);
@@ -116,7 +116,7 @@ void test_biguint_overflow_pow_with_overflow() {
     BigUint second = biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 0});
     BigUint expected_result = biguint_new_with_limbs(
         4, {18446744073709551615ULL, 18446744073709551615ULL, 17870282221894500351ULL, 14019525494141808257ULL});
-    int overflow = biguint_overflow_pow(&first, second);
+    int overflow = biguint_overflow_pow(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
     assert_that(overflow == 1);
@@ -128,7 +128,7 @@ void test_biguint_overflow_pow_mod() {
     BigUint mod = biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 0});
     BigUint expected_result =
         biguint_new_with_limbs(4, {16397732815629627738ULL, 9206660263325832418ULL, 5229948569ULL, 0});
-    biguint_pow_mod(&first, exp, mod);
+    biguint_pow_mod(first, exp, mod, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -139,7 +139,7 @@ void test_biguint_bitand() {
     BigUint second = biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 0});
     BigUint expected_result =
         biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 0});
-    biguint_bitand(&first, second);
+    biguint_bitand(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -149,7 +149,7 @@ void test_biguint_bitor() {
     BigUint second = biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 1ULL});
     BigUint expected_result =
         biguint_new_with_limbs(4, {18446744073709551615ULL, 18446744073709551615ULL, 1099511627775ULL, 1});
-    biguint_bitor(&first, second);
+    biguint_bitor(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -159,7 +159,7 @@ void test_biguint_bitxor() {
     BigUint second = biguint_new_with_limbs(4, {2919980651337220095ULL, 14019525496019259228ULL, 10995116277ULL, 1});
     BigUint expected_result =
         biguint_new_with_limbs(4, {15526763422372331520ULL, 4427218577690292387ULL, 1088516511498ULL, 0});
-    biguint_bitxor(&first, second);
+    biguint_bitxor(first, second, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -167,7 +167,7 @@ void test_biguint_bitxor() {
 void test_biguint_bitnot() {
     BigUint first = biguint_new_with_limbs(4, {18446744073709551615ULL, 18446744073709551615ULL, 1099511627775ULL, 0});
     BigUint expected_result = biguint_new_with_limbs(4, {0, 0, 18446742974197923840ULL, 18446744073709551615ULL});
-    biguint_bitnot(&first);
+    biguint_bitnot(first, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -176,7 +176,7 @@ void test_biguint_shl() {
     BigUint first = biguint_new_with_limbs(4, {18446744073709551615ULL, 18446744073709551615ULL, 1099511627775ULL, 0});
     int shift = 130;
     BigUint expected_result = biguint_new_with_limbs(4, {0, 0, 18446744073709551612ULL, 18446744073709551615ULL});
-    biguint_shl(&first, shift);
+    biguint_shl(first, shift, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }
@@ -185,7 +185,7 @@ void test_biguint_shr() {
     BigUint first = biguint_new_with_limbs(4, {18446744073709551615ULL, 18446744073709551615ULL, 1099511627775ULL, 0});
     int shift = 130;
     BigUint expected_result = biguint_new_with_limbs(4, {274877906943, 0, 0, 0});
-    biguint_shr(&first, shift);
+    biguint_shr(first, shift, &first);
 
     assert_that(biguint_cmp(first, expected_result) == 0);
 }


### PR DESCRIPTION
**Description**
- Refactors `biguint` in `primitive-types` to take an `*out` to which output the result instead of mutating the first param. 
- Checks have been added to account for the different sizes between the numbers.