### PR TITLE
fix: rsa key generation

### DIFF
--- a/libs/digital-signature/src/rsa.c
+++ b/libs/digital-signature/src/rsa.c
@@ -26,15 +26,15 @@
 // 5. finding d as the multiplicative inverse of e
 // 6. releasing the public key as n,e and the private key as n,d
 void rsa_gen_key_pair(RSAKeyPair *key_pair) {
-    int key_size_in_bytes = key_pair->bit_size / 64;
+    int key_limbs_size = key_pair->bit_size / 64;
 
     // prime numbers have to be half the size of the desired key to prevent multiplication overflows
-    BigUint p = biguint_new_heap(key_size_in_bytes / 2);
-    BigUint q = biguint_new_heap(key_size_in_bytes / 2);
+    BigUint p = biguint_new_heap(key_limbs_size / 2);
+    BigUint q = biguint_new_heap(key_limbs_size / 2);
     biguint_random_prime(&p);
     biguint_random_prime(&q);
 
-    BigUint n = biguint_new_heap(key_size_in_bytes);
+    BigUint n = biguint_new_heap(key_limbs_size);
     biguint_mul(p, q, &n);
 
     // Carmichael's totient (lambda) of n outputs the smallest integer m, such that for every integer coprime to n, it
@@ -44,12 +44,12 @@ void rsa_gen_key_pair(RSAKeyPair *key_pair) {
     // lambda(q) = q - 1 hance lambda(n) = lcm(p - 1, q - 1)
     //
     // https://en.wikipedia.org/wiki/Carmichael_function
-    BigUint one = biguint_new_heap(key_size_in_bytes);
+    BigUint one = biguint_new_heap(key_limbs_size);
     biguint_one(&one);
     biguint_sub(p, one, &p);
     biguint_sub(q, one, &q);
 
-    BigUint lambda_n = biguint_new_heap(key_size_in_bytes);
+    BigUint lambda_n = biguint_new_heap(key_limbs_size);
     biguint_lcm(p, q, &lambda_n);
 
     // Now we need to compute the private exponent d as
@@ -63,8 +63,8 @@ void rsa_gen_key_pair(RSAKeyPair *key_pair) {
     // so if we can compute x we get d.
     //
     // Using the extended euclidean algorithm we can compute both x,y obtaining d
-    BigUint e = biguint_new_heap(key_size_in_bytes);
-    BigUint d = biguint_new_heap(key_size_in_bytes);
+    BigUint e = biguint_new_heap(key_limbs_size);
+    BigUint d = biguint_new_heap(key_limbs_size);
     biguint_from_u64(e_const, &e);
     biguint_inverse_mod(e, lambda_n, &d);
 

--- a/libs/digital-signature/tests/rsa.c
+++ b/libs/digital-signature/tests/rsa.c
@@ -1,13 +1,25 @@
 #include <digital-signature/rsa.h>
+#include <math/random.h>
 #include <utils/test.h>
 
 void test_key_generation() {
-    RSAKeyPair key_pair = rsa_key_pair_new(512);
+    const int limbs_size = 8;
+    const int size_in_bits = 8 * 64;
+    RSAKeyPair key_pair = rsa_key_pair_new(size_in_bits);
     rsa_gen_key_pair(&key_pair);
 
-    biguint_println(key_pair.pub.n);
-    biguint_println(key_pair.pub.e);
-    biguint_println(key_pair.priv.d);
+    // verify rsa premise: (m^e)^d = m (mod n)
+    BigUint msg = biguint_new(limbs_size);
+    biguint_random(&msg);
+
+    BigUint left_side = biguint_new(limbs_size);
+    biguint_pow_mod(msg, key_pair.pub.e, key_pair.pub.n, &left_side);
+    biguint_pow_mod(left_side, key_pair.priv.d, key_pair.pub.n, &left_side);
+
+    BigUint right_side = biguint_new(limbs_size);
+    biguint_mod(msg, key_pair.pub.n, &right_side);
+
+    assert_that(biguint_cmp(left_side, right_side) == 0);
 }
 
 int main() {

--- a/libs/digital-signature/tests/rsa.c
+++ b/libs/digital-signature/tests/rsa.c
@@ -3,8 +3,8 @@
 #include <utils/test.h>
 
 void test_key_generation() {
-    const int limbs_size = 8;
-    const int size_in_bits = 8 * 64;
+#define limbs_size 8
+#define size_in_bits 8 * 64
     RSAKeyPair key_pair = rsa_key_pair_new(size_in_bits);
     rsa_gen_key_pair(&key_pair);
 

--- a/libs/math/src/arithmetics.c
+++ b/libs/math/src/arithmetics.c
@@ -29,8 +29,8 @@ void biguint_lcm(BigUint a, BigUint b, BigUint *out) {
 
     BigUint gcd = biguint_new_heap(out->size);
     biguint_gcd(x, y, &gcd);
-    biguint_mul(x, y, &x);
-    biguint_div(x, gcd, out);
+    biguint_mul(x, y, out);
+    biguint_div(*out, gcd, out);
 
     biguint_free(&gcd, &x, &y);
 }

--- a/libs/primitive-types/src/biguint.c
+++ b/libs/primitive-types/src/biguint.c
@@ -4,7 +4,6 @@
 
 int get_min_size(BigUint a, BigUint b) {
     if (a.size < b.size)
-
         return a.size;
     else
         return b.size;
@@ -50,15 +49,14 @@ void biguint_from_u64(uint64_t a, BigUint *out) {
 }
 
 void biguint_cpy(BigUint *dst, BigUint src) {
-    int limit = dst->size;
-    if (dst->size > src.size)
-        limit = src.size;
+    int limit = get_min_size(*dst, src);
 
     for (int i = 0; i < dst->size; i++) {
-        if (i < limit)
+        if (i < limit) {
             dst->limbs[i] = src.limbs[i];
-        else
+        } else {
             dst->limbs[i] = 0;
+        }
     }
 }
 
@@ -276,11 +274,13 @@ void biguint_mul_mod(BigUint a, BigUint b, BigUint m, BigUint *out) {
     int limit = get_min_size_three(a, b, *out);
     // allocate twice the memory to prevent overflow
     BigUint result = biguint_new_heap(limit * 2);
+    BigUint mod = biguint_new_heap(limit * 2);
+    biguint_cpy(&mod, m);
 
     biguint_mul(a, b, &result);
-    biguint_mod(result, m, out);
+    biguint_mod(result, mod, out);
 
-    biguint_free(&result);
+    biguint_free(&result, &mod);
 }
 
 // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
@@ -455,7 +455,9 @@ void biguint_divmod(BigUint a, BigUint b, BigUint *quot, BigUint *rem) {
     while (1) {
         /* rem >= shift_copy */
         if (biguint_cmp(*rem, shift_copy) >= 0) {
-            quot->limbs[shift / 64] |= ((uint64_t)1 << (uint64_t)(shift % 64));
+            if (shift / 64 < quot->size) {
+                quot->limbs[shift / 64] |= ((uint64_t)1 << (uint64_t)(shift % 64));
+            }
             biguint_sub(*rem, shift_copy, rem);
         }
         if (shift == 0)

--- a/libs/primitive-types/src/biguint.c
+++ b/libs/primitive-types/src/biguint.c
@@ -256,13 +256,15 @@ int biguint_overflow_mul(BigUint a, BigUint b, BigUint *out) {
         }
     }
     int overflow = 0;
-    for (int i = 4; i < limit * 2; i++) {
-        if (result[i] != 0) {
-            overflow = 1;
-            break;
+    if (out->size < limit * 2) {
+        for (int i = 4; i < limit * 2 && out->size < limit * 2; i++) {
+            if (result[i] != 0) {
+                overflow = 1;
+                break;
+            }
         }
     }
-    for (int i = 0; i < limit; i++)
+    for (int i = 0; i < out->size; i++)
         out->limbs[i] = result[i];
 
     return overflow;


### PR DESCRIPTION
**Description**
Fixes some `rsa` key generation bugs  related to the management of the biguint sizes, some operations were overflowing because we were not allocating enough space.

Key generation test has been modified to verify the RSA premise:

> *Given three larger integers e,d,n  such that for every integer* $0 \le m \le n$:
> $(m^e)^d \equiv m \mod n$