### PR TITLE
feat: rsa `sign`, `verify` with `PKCS1v15` padding scheme

### DIFF
--- a/libs/digital-signature/deps.mk
+++ b/libs/digital-signature/deps.mk
@@ -1,3 +1,3 @@
-BUILD_DEPS := utils primitive-types math
-TESTS_DEPS := utils primitive-types math
-BENCHMARKS_DEPS := utils primitive-types math
+BUILD_DEPS := utils primitive-types math hashes
+TESTS_DEPS := utils primitive-types math hashes
+BENCHMARKS_DEPS := utils primitive-types math hashes

--- a/libs/digital-signature/include/rsa.h
+++ b/libs/digital-signature/include/rsa.h
@@ -1,6 +1,7 @@
 #ifndef RSA_H
 #define RSA_H
 
+#include <hashes/types.h>
 #include <math/arithmetics.h>
 #include <math/primes.h>
 #include <math/random.h>
@@ -85,7 +86,7 @@ RSAEncryptResult rsa_encrypt_msg_PKCS1v15(UInt8Array msg, RSAPublicKey pub, UInt
  */
 RSADecryptResult rsa_decrypt_msg_PKCS1v15(RSAKeyPair key_pair, UInt8Array cipher, UInt8Array *msg);
 
-RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, UInt8Array *signature);
+RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, HashFunction hash, UInt8Array *signature);
 
 /**
  * @returns

--- a/libs/digital-signature/include/rsa.h
+++ b/libs/digital-signature/include/rsa.h
@@ -1,7 +1,6 @@
 #ifndef RSA_H
 #define RSA_H
 
-#include <hashes/types.h>
 #include <math/arithmetics.h>
 #include <math/primes.h>
 #include <math/random.h>
@@ -23,11 +22,14 @@ typedef struct {
     unsigned int bit_size;
 } RSAKeyPair;
 
+typedef enum { RSA_HASH_MD2, RSA_HASH_MD5, RSA_HASH_SHA1, RSA_HASH_SHA256, RSA_HASH_SHA384, RSA_HASH_SHA512 } RSAHashes;
+
 typedef enum {
     RSA_MessageTooLong,
     RSA_MessageTooShort,
     RSA_InvalidEncodedMessage,
     RSA_InvalidSignature,
+    RSA_HashNotSupported
 } RSAError;
 
 DEFINE_RESULT(struct {}, RSAError, RSAEncryptResult)
@@ -86,7 +88,7 @@ RSAEncryptResult rsa_encrypt_msg_PKCS1v15(UInt8Array msg, RSAPublicKey pub, UInt
  */
 RSADecryptResult rsa_decrypt_msg_PKCS1v15(RSAKeyPair key_pair, UInt8Array cipher, UInt8Array *msg);
 
-RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, HashFunction hash, UInt8Array *signature);
+RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, RSAHashes hash, UInt8Array *signature);
 
 /**
  * @returns

--- a/libs/digital-signature/include/rsa.h
+++ b/libs/digital-signature/include/rsa.h
@@ -26,6 +26,7 @@ typedef enum {
     RSA_MessageTooLong,
     RSA_MessageTooShort,
     RSA_InvalidEncodedMessage,
+    RSA_InvalidSignature,
 } RSAError;
 
 DEFINE_RESULT(struct {}, RSAError, RSAEncryptResult)
@@ -92,6 +93,6 @@ RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, UInt8Array 
  *
  *  - 0: invalid signature
  */
-RSAVerificationResult rsa_verify_signature_PKCS1v15(uint8_t *signature, uint8_t *msg, RSAPublicKey *pub);
+RSAVerificationResult rsa_verify_signature_PKCS1v15(UInt8Array msg, UInt8Array signature, RSAPublicKey pub);
 
 #endif

--- a/libs/digital-signature/include/rsa.h
+++ b/libs/digital-signature/include/rsa.h
@@ -30,6 +30,8 @@ typedef enum {
 
 DEFINE_RESULT(struct {}, RSAError, RSAEncryptResult)
 DEFINE_RESULT(struct {}, RSAError, RSADecryptResult)
+DEFINE_RESULT(struct {}, RSAError, RSASignResult)
+DEFINE_RESULT(struct {}, RSAError, RSAVerificationResult)
 
 #define rsa_key_pair_new(BIT_SIZE)                                                                                     \
     (RSAKeyPair) {                                                                                                     \
@@ -82,13 +84,14 @@ RSAEncryptResult rsa_encrypt_msg_PKCS1v15(UInt8Array msg, RSAPublicKey pub, UInt
  */
 RSADecryptResult rsa_decrypt_msg_PKCS1v15(RSAKeyPair key_pair, UInt8Array cipher, UInt8Array *msg);
 
-void rsa_sign_PKCS1v15(RSAPrivateKey *priv, void *msg, uint8_t *buffer);
+RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, UInt8Array *signature);
+
 /**
  * @returns
  *  - 1: valid signature
  *
  *  - 0: invalid signature
  */
-int rsa_verify_signature_PKCS1v15(uint8_t *signature, uint8_t *msg, RSAPublicKey *pub);
+RSAVerificationResult rsa_verify_signature_PKCS1v15(uint8_t *signature, uint8_t *msg, RSAPublicKey *pub);
 
 #endif

--- a/libs/digital-signature/include/rsa.h
+++ b/libs/digital-signature/include/rsa.h
@@ -22,6 +22,13 @@ typedef struct {
     unsigned int bit_size;
 } RSAKeyPair;
 
+/**
+ * List of RSA-supported and recommended hash algorithms.
+ *
+ * Note: This enumeration includes widely used hash functions for RSA signatures.
+ * However, this library **only supports RSA_HASH_SHA256** for signing and verification.
+ * Attempting to use any other hash will result in RSA_HashNotSupported.
+ */
 typedef enum { RSA_HASH_MD2, RSA_HASH_MD5, RSA_HASH_SHA1, RSA_HASH_SHA256, RSA_HASH_SHA384, RSA_HASH_SHA512 } RSAHashes;
 
 typedef enum {
@@ -88,13 +95,34 @@ RSAEncryptResult rsa_encrypt_msg_PKCS1v15(UInt8Array msg, RSAPublicKey pub, UInt
  */
 RSADecryptResult rsa_decrypt_msg_PKCS1v15(RSAKeyPair key_pair, UInt8Array cipher, UInt8Array *msg);
 
+/**
+ * Signs a message using the RSA PKCS1 v1.5 padding scheme.
+ *
+ * If `signature->array` is NULL or `signature->size` is too small, the buffer will be allocated or reallocated as
+ * needed. The caller is responsible for freeing the allocated memory.
+ *
+ * WARNING: Only RSA_HASH_SHA256 is supported. Using any other hash algorithm will result in RSA_HasNotSupported.
+ *
+ * @param msg       The message to sign.
+ * @param key_pair  The RSA key pair containing the private key.
+ * @param hash      The hash algorithm to use for signing. **Only RSA_HASH_SHA256 is supported.**
+ * @param signature A pointer to a UInt8Array where the signature will be stored.
+ *                  If NULL, a new buffer will be allocated.
+ * @return          RSASignResult containing the signature or an error.
+ */
 RSASignResult rsa_sign_PKCS1v15(UInt8Array msg, RSAKeyPair key_pair, RSAHashes hash, UInt8Array *signature);
 
 /**
- * @returns
- *  - 1: valid signature
+ * Verifies an RSA signature using the PKCS1 v1.5 padding scheme.
  *
- *  - 0: invalid signature
+ * This function checks whether the given signature is valid for the provided message and public key.
+ *
+ * WARNING: Only RSA_HASH_SHA256 is supported. Using any other hash algorithm will result in RSA_HasNotSupported.
+ *
+ * @param msg       The original message.
+ * @param signature The signature to verify.
+ * @param pub       The RSA public key.
+ * @return          RSAVerificationResult indicating whether the signature is valid or an error.
  */
 RSAVerificationResult rsa_verify_signature_PKCS1v15(UInt8Array msg, UInt8Array signature, RSAPublicKey pub);
 

--- a/libs/digital-signature/src/rsa.c
+++ b/libs/digital-signature/src/rsa.c
@@ -244,20 +244,23 @@ RSADecryptResult rsa_decrypt_msg_PKCS1v15(RSAKeyPair key_pair, UInt8Array cipher
 
 void hash_msg(RSAHashes hasher, UInt8Array msg, UInt8Array *hash) {
     switch (hasher) {
-    case RSA_HASH_SHA256:
-        sha256 hasher = sha256_new();
-        sha256_update(&hasher, msg.array, msg.size);
-        u256 msg_digest = sha256_finalize(&hasher);
+    case RSA_HASH_SHA256: {
+        sha256 sha_hasher = sha256_new();
+        sha256_update(&sha_hasher, msg.array, msg.size);
+        u256 msg_digest = sha256_finalize(&sha_hasher);
         u256_get_bytes_big_endian(hash->array, msg_digest);
-        break;
+        return;
+    }
+    default:
+        return;
     };
 }
 
 // write hash function oid to the buffer, it assumes the buffer has enough space
 // returns the size of the
-int write_rsa_hash_with_oid(RSAHashes hasher, UInt8Array hash, UInt8Array *buf) {
+void write_rsa_hash_with_oid(RSAHashes hasher, UInt8Array hash, UInt8Array *buf) {
     switch (hasher) {
-    case RSA_HASH_SHA256:
+    case RSA_HASH_SHA256: {
         // 19 bytes for the oid and 32 for the hash
         int size = 51;
         buf->array = realloc(buf->array, size);
@@ -268,7 +271,10 @@ int write_rsa_hash_with_oid(RSAHashes hasher, UInt8Array hash, UInt8Array *buf) 
         for (int j = 0; j < 32; j++)
             buf->array[i++] = hash.array[j];
 
-        break;
+        return;
+    }
+    default:
+        return;
     };
 }
 

--- a/libs/digital-signature/tests/rsa.c
+++ b/libs/digital-signature/tests/rsa.c
@@ -1,4 +1,5 @@
 #include <digital-signature/rsa.h>
+#include <hashes/sha256.h>
 #include <math/random.h>
 #include <utils/test.h>
 
@@ -51,7 +52,7 @@ void test_signing_msg_is_valid() {
     UInt8Array msg_bytes = {.array = (uint8_t *)msg, .size = strlen(msg)};
 
     UInt8Array signature = {};
-    RSASignResult res = rsa_sign_PKCS1v15(msg_bytes, key_pair, &signature);
+    RSASignResult res = rsa_sign_PKCS1v15(msg_bytes, key_pair, RSA_HASH_SHA256, &signature);
     assert_that(res.success == 1);
 
     RSAVerificationResult verification = rsa_verify_signature_PKCS1v15(msg_bytes, signature, key_pair.pub);

--- a/libs/digital-signature/tests/rsa.c
+++ b/libs/digital-signature/tests/rsa.c
@@ -44,6 +44,43 @@ void test_encrypt_decrypt_msg() {
     free(decrypted_msg.array);
 }
 
+void test_encrypt_decrypt_large_msg() {
+    RSAKeyPair key_pair = rsa_key_pair_new(512);
+    rsa_gen_key_pair(&key_pair);
+
+    // Creating a message too large for RSA (512-bit key, PKCS1 padding leaves ~53 bytes for data)
+    char *msg = "This message is too long for a 512-bit RSA key with PKCS1 padding!";
+    UInt8Array msg_bytes = {.array = (uint8_t *)msg, .size = strlen(msg)};
+
+    UInt8Array cipher = {};
+    RSAEncryptResult res = rsa_encrypt_msg_PKCS1v15(msg_bytes, key_pair.pub, &cipher);
+    assert_that(res.success == 0);
+
+    free(cipher.array);
+}
+
+void test_decrypt_with_wrong_key() {
+    RSAKeyPair key_pair1 = rsa_key_pair_new(512);
+    rsa_gen_key_pair(&key_pair1);
+
+    RSAKeyPair key_pair2 = rsa_key_pair_new(512);
+    rsa_gen_key_pair(&key_pair2);
+
+    char *msg = "This message is encrypted!";
+    UInt8Array msg_bytes = {.array = (uint8_t *)msg, .size = strlen(msg)};
+
+    UInt8Array cipher = {};
+    RSAEncryptResult res = rsa_encrypt_msg_PKCS1v15(msg_bytes, key_pair1.pub, &cipher);
+    assert_that(res.success == 1);
+
+    UInt8Array decrypted_msg = {};
+    RSADecryptResult decrypt_result = rsa_decrypt_msg_PKCS1v15(key_pair2, cipher, &decrypted_msg);
+    assert_that(decrypt_result.success == 0);
+
+    free(cipher.array);
+    free(decrypted_msg.array);
+}
+
 void test_signing_msg_is_valid() {
     RSAKeyPair key_pair = rsa_key_pair_new(512);
     rsa_gen_key_pair(&key_pair);
@@ -59,11 +96,36 @@ void test_signing_msg_is_valid() {
     assert_that(verification.success == 1);
 }
 
+void test_signature_tampering() {
+    RSAKeyPair key_pair = rsa_key_pair_new(512);
+    rsa_gen_key_pair(&key_pair);
+
+    char *msg = "Original message!";
+    UInt8Array msg_bytes = {.array = (uint8_t *)msg, .size = strlen(msg)};
+
+    UInt8Array signature = {};
+    RSASignResult res = rsa_sign_PKCS1v15(msg_bytes, key_pair, RSA_HASH_SHA256, &signature);
+    assert_that(res.success == 1);
+
+    // Tamper signature
+    if (signature.size > 0) {
+        signature.array[0] ^= 0xFF;
+    }
+
+    RSAVerificationResult verification = rsa_verify_signature_PKCS1v15(msg_bytes, signature, key_pair.pub);
+    assert_that(verification.success == 0);
+
+    free(signature.array);
+}
+
 int main() {
     BEGIN_TEST()
     test(test_key_generation);
     test(test_encrypt_decrypt_msg);
+    test(test_encrypt_decrypt_large_msg);
+    test(test_decrypt_with_wrong_key);
     test(test_signing_msg_is_valid);
+    test(test_signature_tampering);
     END_TEST()
 
     return 0;

--- a/libs/digital-signature/tests/rsa.c
+++ b/libs/digital-signature/tests/rsa.c
@@ -61,8 +61,8 @@ void test_signing_msg_is_valid() {
 
 int main() {
     BEGIN_TEST()
-    // test(test_key_generation);
-    // test(test_encrypt_decrypt_msg);
+    test(test_key_generation);
+    test(test_encrypt_decrypt_msg);
     test(test_signing_msg_is_valid);
     END_TEST()
 

--- a/libs/digital-signature/tests/rsa.c
+++ b/libs/digital-signature/tests/rsa.c
@@ -43,10 +43,26 @@ void test_encrypt_decrypt_msg() {
     free(decrypted_msg.array);
 }
 
+void test_signing_msg_is_valid() {
+    RSAKeyPair key_pair = rsa_key_pair_new(512);
+    rsa_gen_key_pair(&key_pair);
+
+    char *msg = "Hello this is my secret message!";
+    UInt8Array msg_bytes = {.array = (uint8_t *)msg, .size = strlen(msg)};
+
+    UInt8Array signature = {};
+    RSASignResult res = rsa_sign_PKCS1v15(msg_bytes, key_pair, &signature);
+    assert_that(res.success == 1);
+
+    RSAVerificationResult verification = rsa_verify_signature_PKCS1v15(msg_bytes, signature, key_pair.pub);
+    assert_that(verification.success == 1);
+}
+
 int main() {
     BEGIN_TEST()
-    test(test_key_generation);
-    test(test_encrypt_decrypt_msg);
+    // test(test_key_generation);
+    // test(test_encrypt_decrypt_msg);
+    test(test_signing_msg_is_valid);
     END_TEST()
 
     return 0;

--- a/libs/hashes/include/types.h
+++ b/libs/hashes/include/types.h
@@ -1,9 +1,0 @@
-
-#ifndef HASHES_TYPES
-#define HASHES_TYPES
-
-typedef enum {
-    SHA256,
-} HashFunction;
-
-#endif HASHES_TYPES

--- a/libs/hashes/include/types.h
+++ b/libs/hashes/include/types.h
@@ -1,0 +1,9 @@
+
+#ifndef HASHES_TYPES
+#define HASHES_TYPES
+
+typedef enum {
+    SHA256,
+} HashFunction;
+
+#endif HASHES_TYPES


### PR DESCRIPTION
**Description**
Implements rsa `sign` and `verify_signature` methods using `PKCS1v15 ` padding scheme.

It also refactors the implementation of `encrypt`, `decrypt` and adds a few more test cases.

Closes #32 