### PR TITLE
refactor: sha256 return bytes intead of u256

### DIFF
--- a/libs/digital-signature/src/rsa.c
+++ b/libs/digital-signature/src/rsa.c
@@ -375,13 +375,13 @@ RSAVerificationResult rsa_verify_signature_PKCS1v15(UInt8Array msg, UInt8Array s
     return Ok(RSAVerificationResult, {});
 };
 
-void hash_msg(RSAHashes hasher, UInt8Array msg, UInt8Array *hash) {
+void hash_msg(RSAHashes hasher, UInt8Array msg, UInt8Array *buf) {
     switch (hasher) {
     case RSA_HASH_SHA256: {
         sha256 sha_hasher = sha256_new();
         sha256_update(&sha_hasher, msg.array, msg.size);
-        u256 msg_digest = sha256_finalize(&sha_hasher);
-        u256_get_bytes_big_endian(hash->array, msg_digest);
+        h256 hash = sha256_finalize(&sha_hasher);
+        memcpy(buf->array, hash.digest, 32);
         return;
     }
     default:

--- a/libs/hashes/include/sha256.h
+++ b/libs/hashes/include/sha256.h
@@ -1,8 +1,8 @@
 #ifndef SHA2_H
 #define SHA2_H
 
+#include "types.h"
 #include <primitive-types/u256.h>
-#include <stdint.h>
 
 typedef struct {
     uint32_t h[8];
@@ -16,6 +16,6 @@ typedef struct {
 
 sha256 sha256_new();
 void sha256_update(sha256 *, uint8_t *bytes, size_t size);
-u256 sha256_finalize(sha256 *);
+h256 sha256_finalize(sha256 *);
 
 #endif

--- a/libs/hashes/include/types.h
+++ b/libs/hashes/include/types.h
@@ -1,0 +1,14 @@
+#ifndef HASHES_TYPES_H
+#define HASHES_TYPES_H
+
+#include <primitive-types/u256.h>
+#include <stdint.h>
+
+#define DEFINE_FIXED_U8_ARRAY(NAME, SIZE)                                                                              \
+    typedef struct {                                                                                                   \
+        uint8_t digest[SIZE];                                                                                          \
+    } NAME;
+
+DEFINE_FIXED_U8_ARRAY(h256, 32)
+
+#endif

--- a/libs/hashes/src/sha256.c
+++ b/libs/hashes/src/sha256.c
@@ -1,4 +1,4 @@
-#include <sha256.h>
+#include <hashes/sha256.h>
 
 /**
  *
@@ -144,17 +144,17 @@ void sha256_update(sha256 *hash, uint8_t *bytes, size_t size) {
     }
 }
 
-u256 sha256_finalize(sha256 *hash) {
-    sha256_apply_padding(hash);
+h256 sha256_finalize(sha256 *hasher) {
+    sha256_apply_padding(hasher);
     // SHA-2 algorithm defines the hash values in big-endian format, but our
     // implementation stores the hash values in little-endian format.
     // we need to convert the hash to big-endian byte order
-    uint8_t bytes[32];
+    h256 hash;
     for (int j = 0; j < 8; ++j) {
         for (int i = 0; i < 4; ++i) {
-            bytes[j * 4 + i] = (hash->h[j] >> (24 - i * 8)) & 0xFF;
+            hash.digest[j * 4 + i] = (hasher->h[j] >> (24 - i * 8)) & 0xFF;
         }
     }
-    u256 digest = u256_from_bytes_big_endian(bytes);
-    return digest;
+
+    return hash;
 };

--- a/libs/hashes/tests/sha256.c
+++ b/libs/hashes/tests/sha256.c
@@ -3,98 +3,106 @@
 #include <utils/test.h>
 
 void test_sha256_empty() {
-    sha256 hash = sha256_new();
-    sha256_update(&hash, (uint8_t *)"", 0);
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256 hasher = sha256_new();
+    sha256_update(&hasher, (uint8_t *)"", 0);
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "1029873362495540970295352123225813227897999006481980349933793970011156"
                             "65086549";
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_single_char() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     uint8_t bytes[1] = "a";
-    sha256_update(&hash, bytes, 1);
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, bytes, 1);
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "9163488015244361753484262128703993804158108125491405800297860105017955"
                             "6493499";
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_short_string() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     uint8_t bytes[3] = "abc";
-    sha256_update(&hash, bytes, 3);
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, bytes, 3);
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "8434236848709080036652383492814226366010488369501651437746298582971681"
                             "7089965"; // SHA-256("abc") result
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_long_string() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     uint8_t bytes[] = "The quick brown fox jumps over the lazy dog";
-    sha256_update(&hash, bytes, strlen((char *)bytes));
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, bytes, strlen((char *)bytes));
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "9754582991727437845042049306863340363436609792361092711364013968352019"
                             "4405778";
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_binary_data() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     uint8_t bytes[] = {0x00, 0x01, 0x02, 0x03, 0xFF};
-    sha256_update(&hash, bytes, sizeof(bytes));
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, bytes, sizeof(bytes));
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "1155050113059766760852447818468967315849566989347365055840175606142539"
                             "40679982"; // SHA-256 of binary data
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_repeated_updates() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     uint8_t part1[] = "Hello, ";
     uint8_t part2[] = "world!";
-    sha256_update(&hash, part1, strlen((char *)part1));
-    sha256_update(&hash, part2, strlen((char *)part2));
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, part1, strlen((char *)part1));
+    sha256_update(&hasher, part2, strlen((char *)part2));
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "2233181402739248830710573607548020574234866647396933363417373207145921"
                             "5699411";
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_mid_input() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     int size = 62;
     uint8_t bytes[size];
     for (int i = 0; i < size - 1; i++)
         bytes[i] = 'a';
     bytes[size - 1] = '\0';
-    sha256_update(&hash, bytes, strlen((char *)bytes));
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, bytes, strlen((char *)bytes));
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "24350659281745930032268338123534478735493466811181"
                             "724436128984886588430415152";
     assert_that(strcmp(str, expected_result) == 0);
 }
 
 void test_sha256_long_input() {
-    sha256 hash = sha256_new();
+    sha256 hasher = sha256_new();
     int size = 1001;
     uint8_t bytes[size];
     for (int i = 0; i < size - 1; i++)
         bytes[i] = 'a';
     bytes[size - 1] = '\0';
 
-    sha256_update(&hash, bytes, strlen((char *)bytes));
-    u256 digest = sha256_finalize(&hash);
-    char *str = u256_to_dec_string(digest);
+    sha256_update(&hasher, bytes, strlen((char *)bytes));
+    h256 hash = sha256_finalize(&hasher);
+    u256 digest_u256 = u256_from_bytes_big_endian(hash.digest);
+    char *str = u256_to_dec_string(digest_u256);
     char *expected_result = "29820712876050628553104236154147713728727538950694"
                             "247640693841099527019527843";
     assert_that(strcmp(str, expected_result) == 0);

--- a/libs/math/tests/arithmetics.c
+++ b/libs/math/tests/arithmetics.c
@@ -128,7 +128,7 @@ int main() {
     BEGIN_TEST()
     test(test_biguint_gcd);
     test(test_biguint_lcm);
-    // test(test_biguint_extended_euclidean_algorithm);
+    test(test_biguint_extended_euclidean_algorithm);
     test(test_biguint_inverse_mod);
     END_TEST()
 

--- a/libs/math/tests/primes.c
+++ b/libs/math/tests/primes.c
@@ -27,9 +27,7 @@ void test_random_prime_works() {
     BigUint a = biguint_new_with_limbs(4, {0});
     biguint_random_prime(&a);
 
-    for (int i = 0; i < 4; i++) {
-        assert_that(!biguint_is_zero(a));
-    }
+    assert_that(biguint_is_prime(a) == 1);
 }
 
 int main() {


### PR DESCRIPTION
**Description**

Refactors `sha256` lib to return a 32 bytes array instead of a `u256`. For this, a new type: `h256` was defined to be able to return stack allocated arrays of fixed size.

Also, some commented tests on `math` lib were uncommented.

Closes #39 