### PR TITLE
feat: short weierstrass curves

### DIFF
--- a/libs/elliptic-curves/deps.mk
+++ b/libs/elliptic-curves/deps.mk
@@ -1,3 +1,3 @@
-BUILD_DEPS := utils primitive-types math hashes
-TESTS_DEPS := utils primitive-types math hashes
-BENCHMARKS_DEPS := utils primitive-types math hashes
+BUILD_DEPS := utils primitive-types math
+TESTS_DEPS := utils primitive-types math
+BENCHMARKS_DEPS := utils primitive-types math

--- a/libs/elliptic-curves/include/curve.h
+++ b/libs/elliptic-curves/include/curve.h
@@ -19,6 +19,7 @@ typedef struct {
     int supports_montgomery_form; // whether the curve can be written in montgomery form
     int supports_edward_form;     // whether the curve can be written in edward form
     CurveExpression default_expression;
+    int points_size_in_bits;
 } EllipticCurve;
 
 #endif

--- a/libs/elliptic-curves/include/point.h
+++ b/libs/elliptic-curves/include/point.h
@@ -17,8 +17,8 @@ typedef struct {
     BigUint x;
     BigUint y;
     BigUint z;
-    int infinity; // whether it represents the point at infinity (1 if it does, 0 otherwise)
-    PointSign sign;
+    int infinity;   // whether it represents the point at infinity (1 if it does, 0 otherwise)
+    PointSign sign; // in compressed form, the point sign to reconstruct the y coordinate
     CurvePointCoordSystem coord;
     CurveExpression expression;
 } CurvePoint;
@@ -26,7 +26,7 @@ typedef struct {
 /**
  * Create a new point on the coord system and expresion
  */
-#define coord_point_new(BIT_SIZE, COORD, EXP)                                                                          \
+#define curve_point_new(BIT_SIZE, COORD, EXP)                                                                          \
     (CurvePoint){                                                                                                      \
         .x = biguint_new(BIT_SIZE / 64),                                                                               \
         .y = biguint_new(BIT_SIZE / 64),                                                                               \
@@ -37,10 +37,28 @@ typedef struct {
         .expression = EXP,                                                                                             \
     };
 
+#define curve_point_new_heap(BIT_SIZE, COORD, EXP)                                                                     \
+    (CurvePoint){                                                                                                      \
+        .x = biguint_new_heap(BIT_SIZE / 64),                                                                          \
+        .y = biguint_new_heap(BIT_SIZE / 64),                                                                          \
+        .z = biguint_new_heap(BIT_SIZE / 64),                                                                          \
+        .infinity = 1,                                                                                                 \
+        .sign = LowerHalf,                                                                                             \
+        .coord = COORD,                                                                                                \
+        .expression = EXP,                                                                                             \
+    };
+
+#define curve_point_free(...)                                                                                          \
+    CurvePoint *ANONYMOUS_VARIABLE(points)[] = {__VA_ARGS__};                                                          \
+    for (size_t i = 0; i < sizeof(ANONYMOUS_VARIABLE(points)) / sizeof(ANONYMOUS_VARIABLE(points)[0]); i++) {          \
+        biguint_free(&ANONYMOUS_VARIABLE(points)[i]->x, &ANONYMOUS_VARIABLE(points)[i]->y,                             \
+                     &ANONYMOUS_VARIABLE(points)[i]->z)                                                                \
+    }
+
 typedef enum {
     CurvePointsCoordMismatch,
-    CurvePointsCurveExpressionMismatch,
-    CurveDoesSupportExpression,
+    CurvePointsExpressionMismatch,
+    CurveDoesNotSupportExpression,
     CurveInvalidPoint
 } CurveOperationError;
 
@@ -50,15 +68,16 @@ DEFINE_RESULT(struct {}, CurveOperationError, CurveOperationResult);
  * Creates a new point on the given coordinate system.
  * The points will belong to the curve default expression
  */
-void curve_point_from_affine(EllipticCurve curve, BigUint x, BigUint y, CurvePoint *);
-void curve_point_from_projective(EllipticCurve curve, BigUint x, BigUint y, BigUint z, CurvePoint *);
-void curve_point_from_compressed(EllipticCurve curve, BigUint x, CurvePoint *);
+void curve_point_from_affine(EllipticCurve curve, CurveExpression exp, BigUint x, BigUint y, CurvePoint *);
+void curve_point_from_projective(EllipticCurve curve, CurveExpression exp, BigUint x, BigUint y, BigUint z,
+                                 CurvePoint *);
+void curve_point_from_compressed(EllipticCurve curve, CurveExpression exp, BigUint x, CurvePoint *);
+void curve_point_from_generator(EllipticCurve curve, BigUint n, CurvePoint *);
 
 CurveOperationResult curve_point_sum(EllipticCurve, CurvePoint, CurvePoint, CurvePoint *out);
-CurveOperationResult curve_point_sub(EllipticCurve, CurvePoint, CurvePoint, CurvePoint *out);
-CurveOperationResult curve_point_mul(EllipticCurve, CurvePoint, CurvePoint, CurvePoint *out);
-CurveOperationResult curve_point_double(EllipticCurve, CurvePoint, CurvePoint *out);
+CurveOperationResult curve_point_mul(EllipticCurve, CurvePoint, BigUint n, CurvePoint *out);
 CurveOperationResult curve_point_inverse(EllipticCurve, CurvePoint, CurvePoint *out);
+CurveOperationResult curve_point_double(EllipticCurve, CurvePoint, CurvePoint *out);
 
 void curve_point_to_affine(CurvePoint *);
 void curve_point_to_compressed(CurvePoint *);
@@ -67,5 +86,22 @@ void curve_point_to_projective(CurvePoint *);
 void curve_point_to_short_weierstrass(CurvePoint *);
 void curve_point_to_montgomery(CurvePoint *);
 void curve_point_to_edwards(CurvePoint *);
+void curve_point_cpy(CurvePoint *dst, CurvePoint src);
+/**
+ * Checks for equality
+ * 1: if equal
+ * 0: if not
+ */
+int curve_point_eq(CurvePoint a, CurvePoint b);
+
+/**
+ * Verifies the point belongs to the curve by computing the expression definition
+ */
+int curve_point_verify(EllipticCurve curve, CurvePoint a);
+
+// prints the curve point
+void curve_point_debug(CurvePoint a);
+
+void curve_point_generator(EllipticCurve curve, CurvePoint *out);
 
 #endif

--- a/libs/elliptic-curves/include/secp256k1.h
+++ b/libs/elliptic-curves/include/secp256k1.h
@@ -26,16 +26,21 @@ static uint64_t n[4] = {
 
 #pragma GCC diagnostic pop
 
+#define secp256k1_points_size_in_bits 256
+
 #define secp256k1()                                                                                                    \
-    (EllipticCurve){.p = biguint_new_from_limbs(4, p),                                                                 \
-                    .a = biguint_new_from_limbs(4, a),                                                                 \
-                    .b = biguint_new_from_limbs(4, b),                                                                 \
-                    .g_x = biguint_new_from_limbs(4, g_x),                                                             \
-                    .g_y = biguint_new_from_limbs(4, g_y),                                                             \
-                    .h = biguint_new_from_limbs(4, h),                                                                 \
-                    .n = biguint_new_from_limbs(4, n),                                                                 \
-                    .supports_edward_form = 0,                                                                         \
-                    .supports_montgomery_form = 0,                                                                     \
-                    .default_expression = ShortWeierstrass};
+    (EllipticCurve){                                                                                                   \
+        .p = biguint_new_from_limbs(4, p),                                                                             \
+        .a = biguint_new_from_limbs(4, a),                                                                             \
+        .b = biguint_new_from_limbs(4, b),                                                                             \
+        .g_x = biguint_new_from_limbs(4, g_x),                                                                         \
+        .g_y = biguint_new_from_limbs(4, g_y),                                                                         \
+        .h = biguint_new_from_limbs(4, h),                                                                             \
+        .n = biguint_new_from_limbs(4, n),                                                                             \
+        .supports_edward_form = 0,                                                                                     \
+        .supports_montgomery_form = 0,                                                                                 \
+        .default_expression = ShortWeierstrass,                                                                        \
+        .points_size_in_bits = secp256k1_points_size_in_bits,                                                          \
+    };
 
 #endif

--- a/libs/elliptic-curves/include/short_weierstrass.h
+++ b/libs/elliptic-curves/include/short_weierstrass.h
@@ -1,0 +1,11 @@
+#ifndef ELLIPTIC_CURVES_SHORT_WEIERSTRASS
+#define ELLIPTIC_CURVES_SHORT_WEIERSTRASS
+
+#include "point.h"
+
+CurveOperationResult short_weierstrass_point_sum(EllipticCurve, CurvePoint, CurvePoint, CurvePoint *out);
+CurveOperationResult short_weierstrass_point_double(EllipticCurve, CurvePoint, CurvePoint *out);
+CurveOperationResult short_weierstrass_point_mul(EllipticCurve, CurvePoint, BigUint n, CurvePoint *out);
+CurveOperationResult short_weierstrass_point_inverse(EllipticCurve, CurvePoint, CurvePoint *out);
+
+#endif

--- a/libs/elliptic-curves/readme.md
+++ b/libs/elliptic-curves/readme.md
@@ -7,3 +7,4 @@
   - [Bitcoin implementation](https://github.com/bitcoin-core/secp256k1)
   - [Elliptic curve cryptography - Wikipedia](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography)
   - [Moon math - Chapter 5](https://github.com/LeastAuthority/moonmath-manual/blob/main/chapters/elliptic-curves-moonmath.tex)
+  - [Hyperelliptic](https://hyperelliptic.org/EFD/g1p/index.html)

--- a/libs/elliptic-curves/src/point.c
+++ b/libs/elliptic-curves/src/point.c
@@ -1,0 +1,85 @@
+#include <point.h>
+#include <short_weierstrass.h>
+
+void curve_point_debug(CurvePoint a) {
+    printf("X: ");
+    biguint_println(a.x);
+    printf("Y: ");
+    biguint_println(a.y);
+    printf("Z: ");
+    biguint_println(a.z);
+    printf("infinity: %d\n", a.infinity);
+    printf("coord system: %d\n", a.coord);
+    printf("expression: %d\n", a.expression);
+    printf("sign: %d\n", a.sign);
+};
+
+void curve_point_generator(EllipticCurve curve, CurvePoint *out) {
+    biguint_cpy(&out->x, curve.g_x);
+    biguint_cpy(&out->y, curve.g_y);
+    biguint_one(&out->z);
+    out->coord = Affine;
+    out->infinity = 0;
+    out->expression = ShortWeierstrass;
+}
+
+void curve_point_from_generator(EllipticCurve curve, BigUint n, CurvePoint *out) {
+    CurvePoint generator = curve_point_new_heap(curve.points_size_in_bits, Affine, ShortWeierstrass);
+    curve_point_generator(curve, &generator);
+    curve_point_mul(curve, generator, n, out);
+
+    curve_point_free(&generator);
+};
+
+CurveOperationResult curve_point_sum(EllipticCurve curve, CurvePoint a, CurvePoint b, CurvePoint *out) {
+    if (a.expression != b.expression)
+        return Err(CurveOperationResult, CurvePointsExpressionMismatch);
+
+    if (a.coord != b.coord)
+        return Err(CurveOperationResult, CurvePointsCoordMismatch);
+
+    // if (!curve_point_verify(curve, a) || !curve_point_verify(curve, b))
+    //     return Err(CurveOperationResult, CurveInvalidPoint);
+
+    switch (a.expression) {
+    case ShortWeierstrass:
+        return short_weierstrass_point_sum(curve, a, b, out);
+    default:
+        return Err(CurveOperationResult, CurveDoesNotSupportExpression);
+    }
+};
+
+CurveOperationResult curve_point_mul(EllipticCurve curve, CurvePoint a, BigUint n, CurvePoint *out) {
+    // if (!curve_point_verify(curve, a) || !curve_point_verify(curve, b))
+    //     return Err(CurveOperationResult, CurveInvalidPoint);
+
+    switch (a.expression) {
+    case ShortWeierstrass:
+        return short_weierstrass_point_mul(curve, a, n, out);
+    default:
+        return Err(CurveOperationResult, CurveDoesNotSupportExpression);
+    }
+};
+
+void curve_point_cpy(CurvePoint *dst, CurvePoint src) {
+    biguint_cpy(&dst->x, src.x);
+    biguint_cpy(&dst->y, src.y);
+    biguint_cpy(&dst->z, src.z);
+
+    dst->coord = src.coord;
+    dst->expression = src.expression;
+    dst->sign = src.sign;
+    dst->infinity = src.infinity;
+}
+
+int curve_point_eq(CurvePoint a, CurvePoint b) {
+    if (a.coord != b.coord || a.expression != b.expression || a.infinity != b.infinity) {
+        return 0;
+    }
+
+    if (biguint_cmp(a.x, b.x) != 0 || biguint_cmp(a.y, b.y) != 0 || biguint_cmp(a.z, b.z) != 0) {
+        return 0;
+    }
+
+    return 1;
+}

--- a/libs/elliptic-curves/src/short_weierstrass.c
+++ b/libs/elliptic-curves/src/short_weierstrass.c
@@ -1,0 +1,136 @@
+#include <short_weierstrass.h>
+
+CurveOperationResult double_affine(EllipticCurve curve, CurvePoint a, CurvePoint *out) {
+    if (a.infinity) {
+        curve_point_cpy(out, a);
+        return Ok(CurveOperationResult, {});
+    }
+    BigUint lambda = biguint_new_heap(curve.points_size_in_bits / 64);
+    BigUint num = biguint_new_heap(curve.points_size_in_bits / 64);
+    BigUint denom = biguint_new_heap(curve.points_size_in_bits / 64);
+
+    BigUint scalar = biguint_new(1);
+
+    biguint_from_u64(2, &scalar);
+    biguint_pow_mod(a.x, scalar, curve.p, &num);
+    biguint_from_u64(3, &scalar);
+    biguint_mul(scalar, a.x, &num);
+    biguint_add_mod(num, curve.a, curve.p, &num);
+
+    biguint_from_u64(2, &scalar);
+    biguint_mul_mod(a.y, scalar, curve.p, &denom);
+
+    biguint_div(num, denom, &lambda);
+    biguint_pow_mod(lambda, scalar, curve.p, &out->x);
+    biguint_sub_mod(out->x, a.x, curve.p, &out->x);
+    biguint_sub_mod(out->x, a.x, curve.p, &out->x);
+
+    biguint_sub_mod(a.x, out->x, curve.p, &out->y);
+    biguint_mul_mod(lambda, out->y, curve.p, &out->y);
+    biguint_sub_mod(out->y, a.y, curve.p, &out->y);
+
+    biguint_free(&lambda, &num, &denom);
+}
+
+CurveOperationResult sum_affine(EllipticCurve curve, CurvePoint a, CurvePoint b, CurvePoint *out) {
+    if (a.infinity) {
+        curve_point_cpy(out, b);
+        return Ok(CurveOperationResult, {});
+    }
+
+    if (b.infinity) {
+        curve_point_cpy(out, a);
+        return Ok(CurveOperationResult, {});
+    }
+
+    if (curve_point_eq(a, b)) {
+        return double_affine(curve, a, out);
+    }
+
+    // validations went through, now sum the points using the chord rule
+    BigUint lambda = biguint_new_heap(curve.points_size_in_bits / 64);
+    BigUint num = biguint_new_heap(curve.points_size_in_bits / 64);
+    BigUint denom = biguint_new_heap(curve.points_size_in_bits / 64);
+
+    biguint_sub_mod(b.y, a.y, curve.p, &num);
+    biguint_sub_mod(b.x, a.x, curve.p, &denom);
+    biguint_div(num, denom, &lambda);
+
+    BigUint two = biguint_new(1);
+    // TODO add comment explaining formula
+    biguint_from_u64(2, &two);
+    biguint_pow_mod(lambda, two, curve.p, &out->x);
+    biguint_sub_mod(out->x, a.x, curve.p, &out->x);
+    biguint_sub_mod(out->x, b.x, curve.p, &out->x);
+
+    biguint_sub_mod(a.x, out->x, curve.p, &out->y);
+    biguint_mul_mod(lambda, out->y, curve.p, &out->y);
+    biguint_sub_mod(out->y, a.y, curve.p, &out->y);
+
+    biguint_free(&lambda, &num, &denom);
+}
+
+CurveOperationResult double_projective(EllipticCurve curve, CurvePoint a, CurvePoint *out) {}
+
+CurveOperationResult sum_projective(EllipticCurve curve, CurvePoint a, CurvePoint b, CurvePoint *out) {}
+
+CurveOperationResult double_compressed(EllipticCurve curve, CurvePoint a, CurvePoint *out) {}
+
+CurveOperationResult sum_compressed(EllipticCurve curve, CurvePoint a, CurvePoint b, CurvePoint *out) {}
+
+CurveOperationResult short_weierstrass_point_sum(EllipticCurve curve, CurvePoint a, CurvePoint b, CurvePoint *out) {
+    switch (a.coord) {
+    case Affine:
+        return sum_affine(curve, a, b, out);
+    case Projective:
+        return sum_projective(curve, a, b, out);
+    case Compressed:
+        return sum_compressed(curve, a, b, out);
+    }
+}
+
+CurveOperationResult short_weierstrass_point_double(EllipticCurve curve, CurvePoint a, CurvePoint *out) {
+    switch (a.coord) {
+    case Affine:
+        return double_affine(curve, a, out);
+    case Projective:
+        return double_projective(curve, a, out);
+    case Compressed:
+        return double_compressed(curve, a, out);
+    }
+}
+
+CurveOperationResult short_weierstrass_point_inverse(EllipticCurve, CurvePoint, CurvePoint *out) {}
+
+CurveOperationResult short_weierstrass_point_mul(EllipticCurve curve, CurvePoint a, BigUint n, CurvePoint *out) {
+    // for now we are naively applying a sum n times
+    // for a start, we could apply exponentiation by square to reduce it by quite a lot
+    CurveOperationResult (*operation)(EllipticCurve, CurvePoint, CurvePoint, CurvePoint *out) = NULL;
+    switch (a.coord) {
+    case Affine:
+        operation = sum_affine;
+        break;
+    case Projective:
+        operation = sum_projective;
+        break;
+    case Compressed:
+        operation = sum_compressed;
+    };
+
+    CurvePoint base = curve_point_new_heap(curve.points_size_in_bits, a.coord, a.expression);
+    curve_point_cpy(&base, a);
+    BigUint i = biguint_new_heap(curve.points_size_in_bits / 64);
+    BigUint one = biguint_new(1);
+    biguint_one(&one);
+
+    for (; biguint_cmp(i, n) < 0; biguint_add(i, one, &i)) {
+        CurveOperationResult result = operation(curve, a, base, &a);
+        if (!result.success) {
+            biguint_free(&i);
+            return result;
+        }
+    }
+
+    biguint_free(&i);
+    curve_point_free(&base);
+}

--- a/libs/elliptic-curves/tests/point.c
+++ b/libs/elliptic-curves/tests/point.c
@@ -1,0 +1,72 @@
+
+#include <elliptic-curves/point.h>
+#include <elliptic-curves/secp256k1.h>
+#include <math/random.h>
+#include <primitive-types/biguint.h>
+#include <utils/test.h>
+
+void test_short_weierstrass_sum() {
+    EllipticCurve secp256k1 = secp256k1();
+    CurvePoint a = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    BigUint n_a = biguint_new(1);
+    biguint_from_u64(2, &n_a);
+    curve_point_from_generator(secp256k1, n_a, &a);
+
+    CurvePoint b = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    BigUint n_b = biguint_new(1);
+    biguint_from_u64(3, &n_b);
+    curve_point_from_generator(secp256k1, n_b, &b);
+
+    CurvePoint result = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    curve_point_sum(secp256k1, a, b, &result);
+
+    BigUint expected_x = biguint_new(secp256k1_points_size_in_bits / 64);
+    biguint_from_dec_string("", &expected_x);
+    BigUint expected_y = biguint_new(secp256k1_points_size_in_bits / 64);
+    biguint_from_dec_string("", &expected_y);
+
+    assert_that(biguint_cmp(result.x, expected_x) == 0);
+    assert_that(biguint_cmp(result.y, expected_y) == 0);
+}
+
+void test_short_weierstrass_sum_should_double_on_equal_points() {
+    EllipticCurve secp256k1 = secp256k1();
+    CurvePoint a = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    CurvePoint b = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    CurvePoint result = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    curve_point_sum(secp256k1, a, b, &result);
+
+    BigUint expected_x = biguint_new(secp256k1_points_size_in_bits / 64);
+    biguint_from_dec_string("", &expected_x);
+    BigUint expected_y = biguint_new(secp256k1_points_size_in_bits / 64);
+    biguint_from_dec_string("", &expected_y);
+
+    assert_that(biguint_cmp(result.x, expected_x) == 0);
+    assert_that(biguint_cmp(result.y, expected_y) == 0);
+}
+
+void test_short_weierstrass_sum_should_return_same_on_infinite_point() {
+    EllipticCurve secp256k1 = secp256k1();
+    CurvePoint a = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    CurvePoint b = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    CurvePoint result = curve_point_new(secp256k1_points_size_in_bits, Affine, ShortWeierstrass);
+    curve_point_sum(secp256k1, a, b, &result);
+
+    BigUint expected_x = biguint_new(secp256k1_points_size_in_bits / 64);
+    biguint_from_dec_string("", &expected_x);
+    BigUint expected_y = biguint_new(secp256k1_points_size_in_bits / 64);
+    biguint_from_dec_string("", &expected_y);
+
+    assert_that(biguint_cmp(result.x, expected_x) == 0);
+    assert_that(biguint_cmp(result.y, expected_y) == 0);
+}
+
+int main() {
+    BEGIN_TEST()
+    test(test_short_weierstrass_sum);
+    // test(test_short_weierstrass_sum_should_double_on_equal_points);
+    // test(test_short_weierstrass_sum_should_return_same_on_infinite_point);
+    END_TEST()
+
+    return 0;
+}


### PR DESCRIPTION
**Description**
Implements short weierstrass curves operations + starts `point.c` abstractions to call the respective operations, based on the defined expression.

Closes #48 